### PR TITLE
Fix memory leaks in iOS

### DIFF
--- a/sonic-iOS/Sonic/Cache/SonicCache.m
+++ b/sonic-iOS/Sonic/Cache/SonicCache.m
@@ -514,6 +514,7 @@ typedef NS_ENUM(NSUInteger, SonicCacheType) {
         NSDateFormatter *dateFormatter = [NSDateFormatter new];
         [dateFormatter setDateFormat:@"EEE, dd MMM yyyy HH:mm:ss zzz"];
         NSDate *date = [dateFormatter dateFromString:expire];
+        [dateFormatter release];
         unsigned long long expireTime = (unsigned long long)[date timeIntervalSince1970];
         
         if (!date) {

--- a/sonic-iOS/Sonic/Network/SonicConnection.m
+++ b/sonic-iOS/Sonic/Network/SonicConnection.m
@@ -75,6 +75,10 @@
 - (void)stopLoading
 {
     self.delegate = nil;
+    //fix:https://github.com/Tencent/VasSonic/issues/253
+    for (NSOperation *operation in self.delegateQueue.operations) {
+        [operation cancel];
+    }
     self.delegateQueue = nil;
     
     if (self.dataTask && self.dataTask.state == NSURLSessionTaskStateRunning) {

--- a/sonic-iOS/Sonic/Network/SonicConnection.m
+++ b/sonic-iOS/Sonic/Network/SonicConnection.m
@@ -56,6 +56,7 @@
     
     self.dataTask = nil;
     self.dataSession = nil;
+    self.delegateQueue = nil;
     
     [super dealloc];
 }
@@ -87,6 +88,8 @@
     }else{
         [self.dataSession invalidateAndCancel];
     }
+    self.dataTask = nil;
+    self.dataSession = nil;
 }
 
 #pragma mark - NSURLSessionDelegate

--- a/sonic-iOS/Sonic/Network/SonicServer.m
+++ b/sonic-iOS/Sonic/Network/SonicServer.m
@@ -383,7 +383,12 @@ static NSLock *sonicRequestClassLock;
         // fix Weak-Etag case like -> etag: W/"66f0-m2UmCBEh78dNYPv+boO5ETXk4FU".[https://github.com/Tencent/VasSonic/issues/128]
         NSString *eTag = [headers objectForKey:[SonicHeaderKeyETag lowercaseString]];
         if ([eTag hasPrefix:@"W/"] && eTag.length > 3) {
-            [headers setValue:[eTag substringWithRange:NSMakeRange(2, eTag.length - 3)] forKey:[SonicHeaderKeyETag lowercaseString]];
+            // fix Weak-Etag get value length error
+            NSString *eTagValue = [eTag substringFromIndex:2];
+            if ([eTagValue hasPrefix:@"\""] && [eTagValue hasSuffix:@"\""] && eTagValue.length > 3) {
+                eTagValue = [eTagValue substringWithRange:NSMakeRange(1, eTagValue.length - 2)];
+            }
+            [headers setValue:eTagValue forKey:[SonicHeaderKeyETag lowercaseString]];
         }
         
         NSHTTPURLResponse *newResponse = [[[NSHTTPURLResponse alloc]initWithURL:response.URL statusCode:response.statusCode HTTPVersion:nil headerFields:headers]autorelease];

--- a/sonic-iOS/SonicSample/SonicSample/SonicJSContext.h
+++ b/sonic-iOS/SonicSample/SonicSample/SonicJSContext.h
@@ -35,7 +35,8 @@ JSExportAs(getPerformance,
 
 @interface SonicJSContext : NSObject<SonicJSExport>
 
-@property (nonatomic,weak)SonicWebViewController *owner;
+//fix:https://github.com/Tencent/VasSonic/issues/251, make sure jscontext execute correct
+@property (nonatomic,strong)SonicWebViewController *owner;
 
 - (void)getDiffData:(NSDictionary *)option withCallBack:(JSValue *)jscallback;
 

--- a/sonic-iOS/SonicSample/SonicSample/SonicJSContext.h
+++ b/sonic-iOS/SonicSample/SonicSample/SonicJSContext.h
@@ -35,8 +35,7 @@ JSExportAs(getPerformance,
 
 @interface SonicJSContext : NSObject<SonicJSExport>
 
-//fix:https://github.com/Tencent/VasSonic/issues/251, make sure jscontext execute correct
-@property (nonatomic,strong)SonicWebViewController *owner;
+@property (nonatomic,weak)SonicWebViewController *owner;
 
 - (void)getDiffData:(NSDictionary *)option withCallBack:(JSValue *)jscallback;
 

--- a/sonic-iOS/SonicSample/SonicSample/SonicJSContext.m
+++ b/sonic-iOS/SonicSample/SonicSample/SonicJSContext.m
@@ -24,20 +24,19 @@
 
 - (void)getDiffData:(NSDictionary *)option withCallBack:(JSValue *)jscallback
 {
-    JSValue *callback = self.owner.jscontext.globalObject;
+    SonicWebViewController *owner = self.owner;
+    if (!owner) { return; }
     
-    __weak typeof(self) weakSelf = self;
-    [[SonicEngine sharedEngine] sonicUpdateDiffDataByWebDelegate:self.owner completion:^(NSDictionary *result) {
-       
-        if (result) {
-            
+    __weak typeof(SonicWebViewController *) weakOwner = owner;
+    [[SonicEngine sharedEngine] sonicUpdateDiffDataByWebDelegate:owner completion:^(NSDictionary *result) {
+        __strong typeof(SonicWebViewController *) strongOwner = weakOwner;
+        if (strongOwner && result) {
+            JSValue *callback = strongOwner.jscontext.globalObject;
             NSData *json = [NSJSONSerialization dataWithJSONObject:result options:NSJSONWritingPrettyPrinted error:nil];
             NSString *jsonStr = [[NSString alloc]initWithData:json encoding:NSUTF8StringEncoding];
             
             [callback invokeMethod:@"getDiffDataCallback" withArguments:@[jsonStr]];
         }
-        //fix:https://github.com/Tencent/VasSonic/issues/251
-        weakSelf.owner = nil;
     }];
 }
 

--- a/sonic-iOS/SonicSample/SonicSample/SonicJSContext.m
+++ b/sonic-iOS/SonicSample/SonicSample/SonicJSContext.m
@@ -26,6 +26,7 @@
 {
     JSValue *callback = self.owner.jscontext.globalObject;
     
+    __weak typeof(self) weakSelf = self;
     [[SonicEngine sharedEngine] sonicUpdateDiffDataByWebDelegate:self.owner completion:^(NSDictionary *result) {
        
         if (result) {
@@ -35,7 +36,8 @@
             
             [callback invokeMethod:@"getDiffDataCallback" withArguments:@[jsonStr]];
         }
-        
+        //fix:https://github.com/Tencent/VasSonic/issues/251
+        weakSelf.owner = nil;
     }];
 }
 

--- a/sonic-iOS/SonicSample/SonicSample/SonicWebViewController.h
+++ b/sonic-iOS/SonicSample/SonicSample/SonicWebViewController.h
@@ -25,7 +25,7 @@
 @property (nonatomic,strong)NSString *url;
 @property (nonatomic,strong)UIWebView *webView;
 @property (nonatomic,assign)long long clickTime;
-@property (nonatomic,strong)JSContext *jscontext;
+@property (nonatomic,weak)JSContext *jscontext;
 
 - (instancetype)initWithUrl:(NSString *)aUrl useSonicMode:(BOOL)isSonic unStrictMode:(BOOL)state;
 

--- a/sonic-iOS/SonicSample/SonicSample/SonicWebViewController.m
+++ b/sonic-iOS/SonicSample/SonicSample/SonicWebViewController.m
@@ -60,9 +60,7 @@
 
 - (void)dealloc
 {
-    self.sonicContext.owner = nil;
     self.sonicContext = nil;
-    self.jscontext = nil;
     [[SonicEngine sharedEngine] removeSessionWithWebDelegate:self];
 }
 


### PR DESCRIPTION
I strongly recommend that transition `iOS` to `ARC`, just like discussion in #259 , I think `ARC` is more safety, robust and memory friendly.

This `PR` fixes:
1. Memory leaks of `NSDateFormatter`.
2. Memory leaks of `NSURLSession` and related classes.
3. Memory leaks of `SonicConnection`. 
4. Memory leaks of `delegateQueue` in `SonicConnection`. 
5. ...... any related memory leaks.